### PR TITLE
Remove composer/installers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
     "issues": "https://github.com/frozzare/php-personnummer/issues"
   },
   "require": {
-    "php": ">=5.3.0",
-    "composer/installers": "~1.0"
+    "php": ">=5.3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
Since the package type `utility` isn't a type supported by the installers package, it's not needed.