### PR TITLE
Fix for short format when older than 100 years

### DIFF
--- a/src/Personnummer.php
+++ b/src/Personnummer.php
@@ -54,7 +54,11 @@ final class Personnummer
         $check   = $match[7];
 
         if (!in_array($sep, array('-', '+'))) {
-            $sep = '-';
+            if (empty($century) || date('Y') - intval(strval($century) . strval($year)) < 100) {
+                $sep = '-';
+            } else {
+                $sep = '+';
+            }
         }
 
         if (empty($century)) {

--- a/tests/PersonnummerTest.php
+++ b/tests/PersonnummerTest.php
@@ -69,6 +69,7 @@ class PersonnummerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('640823-3234', Personnummer::format('196408233234'));
         $this->assertEquals('000101-0107', Personnummer::format('0001010107'));
         $this->assertEquals('000101-0107', Personnummer::format('000101-0107'));
+        $this->assertEquals('130401+2931', Personnummer::format('191304012931'));
 
         $this->assertEquals('196403273813', Personnummer::format(6403273813, true));
         $this->assertEquals('195108189167', Personnummer::format('510818-9167', true));


### PR DESCRIPTION
Found a small edge case where the separator became wrong