### PR TITLE
Fix get age-method in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ use Personnummer\Personnummer;
 ```php
 use Personnummer\Personnummer;
 
-(new Personnummer('1212121212'))->age;
+(new Personnummer('1212121212'))->getAge();
 //=> 7
 ```
 


### PR DESCRIPTION
**Type of change**

- [ ] New feature
- [ ] Bug fix
- [ ] Security patch
- [x] Documentation update

**Description**

The `age`-attribute is no longer available, instead the `getAge()`-method is used.

**Related issue**

*N/A*

**Motivation**

*N/A*

**Checklist**

- [x] I have read the **CONTRIBUTING** document.
- [x] I have read and accepted the **Code of conduct**
- [x] Tests passes.
- [ ] Style lints passes.
- [ ] Documentation of new public methods exists.
<!-- The following are only needed if this is a new feature. -->
<!-- - [ ] New tests added which covers the added code. -->
<!-- - [ ] Documentation is updated. -->
<!-- - [ ] This PR includes breaking changes. -->
