### PR TITLE
Support for interim numbers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ composer require personnummer/personnummer
 
 #### Instance
 | Method               | Arguments       | Returns |
-| ---------------------|:----------------|--------:|
+|----------------------|:----------------|--------:|
 | format               | bool longFormat | string  |
 | getAge               | none            | int     |
 | isMale               | none            | bool    |
 | isFemale             | none            | bool    |
 | isCoordinationNumber | none            | bool    |
+| isInterimNumber      | none            | bool    |
 
 | Property | Type   | Description                 |
 | ---------|:-------|----------------------------:|
@@ -39,9 +40,10 @@ composer require personnummer/personnummer
 When a personnummer is invalid a PersonnummerException is thrown.
 
 ## Options
-| Option                  | Type | Default | Description                 |
-| ------------------------|:-----|:--------|:---------------------------:|
+| Option                  | Type | Default |         Description         |
+|-------------------------|:-----|:--------|:---------------------------:|
 | allowCoordinationNumber | bool | true    | Accept coordination numbers |
+| allowInterimNumber      | bool | false   |  Accept interim/T numbers  |
 
 ## Examples
 

--- a/src/Personnummer.php
+++ b/src/Personnummer.php
@@ -182,6 +182,18 @@ final class Personnummer implements PersonnummerInterface
         $this->options = $this->parseOptions($options);
         $this->parts   = self::getParts($ssn);
 
+        // Sanity checks.
+        $ssn = trim($ssn);
+        $len = strlen($ssn);
+        if ($len > 13 || $len < 10) {
+            throw new PersonnummerException(
+                sprintf(
+                    'Input string too %s',
+                    $len < 10 ? 'short' : 'long'
+                )
+            );
+        }
+
         if (!$this->isValid()) {
             throw new PersonnummerException();
         }

--- a/src/Personnummer.php
+++ b/src/Personnummer.php
@@ -257,6 +257,7 @@ final class Personnummer implements PersonnummerInterface
     {
         $defaultOptions = [
             'allowCoordinationNumber' => true,
+            'allowInterimNumber' => false,
         ];
 
         if ($unknownKeys = array_diff_key($options, $defaultOptions)) {

--- a/src/Personnummer.php
+++ b/src/Personnummer.php
@@ -25,6 +25,8 @@ final class Personnummer implements PersonnummerInterface
 
     private array $options;
 
+    private bool $isInterim;
+
     /**
      * @inheritDoc
      */
@@ -86,6 +88,14 @@ final class Personnummer implements PersonnummerInterface
         $parts = $this->parts;
 
         return checkdate((int)$parts['month'], $parts['day'] - 60, $parts['fullYear']);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isInterimNumber(): bool
+    {
+        return $this->isInterim;
     }
 
     /**
@@ -256,9 +266,9 @@ final class Personnummer implements PersonnummerInterface
 
         // Correct interim if allowed.
         $interimTest = '/(?![-+])\D/';
-        $isInterim = preg_match($interimTest, $parts['original']) !== 0;
+        $this->isInterim = preg_match($interimTest, $parts['original']) !== 0;
 
-        if ($this->options['allowInterimNumber'] === false && $isInterim) {
+        if ($this->options['allowInterimNumber'] === false && $this->isInterim) {
             throw new PersonnummerException(sprintf(
                 '%s contains non-integer characters and options are set to not allow interim numbers',
                 $parts['original']
@@ -266,7 +276,7 @@ final class Personnummer implements PersonnummerInterface
         }
 
         $num = $parts['num'];
-        if ($this->options['allowInterimNumber'] && $isInterim) {
+        if ($this->options['allowInterimNumber'] && $this->isInterim) {
             $num = preg_replace($interimTest, '1', $num);
         }
 

--- a/src/PersonnummerInterface.php
+++ b/src/PersonnummerInterface.php
@@ -72,6 +72,13 @@ interface PersonnummerInterface
      */
     public function isCoordinationNumber(): bool;
 
+    /**
+     * Check if the Swedish social security number is an interim number.
+     *
+     * @return bool
+     */
+    public function isInterimNumber(): bool;
+
     public function __construct(string $ssn, array $options = []);
 
     /**

--- a/tests/InterimNumberTest.php
+++ b/tests/InterimNumberTest.php
@@ -61,6 +61,13 @@ class InterimNumberTest extends TestCase
     }
 
     #[DataProvider('validProvider')]
+    public function testIsInterim(PersonnummerData $num): void
+    {
+        self::assertTrue(Personnummer::parse($num->longFormat, $this->options)->isInterimNumber());
+        self::assertTrue(Personnummer::parse($num->separatedFormat, $this->options)->isInterimNumber());
+    }
+
+    #[DataProvider('validProvider')]
     public function testFormatLongInterim(PersonnummerData $num): void
     {
         $p = Personnummer::parse($num->longFormat, $this->options);

--- a/tests/InterimNumberTest.php
+++ b/tests/InterimNumberTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Personnummer\Tests;
+
+use Jchook\AssertThrows\AssertThrows;
+use Personnummer\Personnummer;
+use Personnummer\PersonnummerException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class InterimNumberTest extends TestCase
+{
+    use AssertThrows;
+
+    private static ?array $interim = null;
+
+    private array $options = [
+        'allowInterimNumber' => true,
+    ];
+
+    private static function init(): void
+    {
+        if (self::$interim === null) {
+            $data = json_decode(file_get_contents('https://raw.githubusercontent.com/personnummer/meta/master/testdata/interim.json'), true, 512, JSON_THROW_ON_ERROR); // phpcs:ignore
+            self::$interim = array_map(
+                static fn(array $p) => new PersonnummerData($p),
+                $data,
+            );
+        }
+    }
+
+    public static function validProvider(): array
+    {
+        self::init();
+        return array_map(
+            static fn(PersonnummerData $p) => ['num' => $p],
+            array_filter(self::$interim, static fn($p) => $p->valid)
+        );
+    }
+    public static function invalidProvider(): array
+    {
+        self::init();
+        return array_map(
+            static fn(PersonnummerData $p) => ['num' => $p],
+            array_filter(self::$interim, static fn($p) => !$p->valid)
+        );
+    }
+
+    #[DataProvider('validProvider')]
+    public function testValidateInterim(PersonnummerData $num): void
+    {
+        self::assertTrue(Personnummer::valid($num->longFormat, $this->options));
+        self::assertTrue(Personnummer::valid($num->separatedFormat, $this->options));
+    }
+
+    #[DataProvider('invalidProvider')]
+    public function testValidateInvalidInterim(PersonnummerData $num): void
+    {
+        self::assertFalse(Personnummer::valid($num->longFormat, $this->options));
+        self::assertFalse(Personnummer::valid($num->separatedFormat, $this->options));
+    }
+
+    #[DataProvider('validProvider')]
+    public function testFormatLongInterim(PersonnummerData $num): void
+    {
+        $p = Personnummer::parse($num->longFormat, $this->options);
+        self::assertEquals($p->format(true), $num->longFormat);
+        self::assertEquals($p->format(false), $num->separatedFormat);
+    }
+
+    #[DataProvider('validProvider')]
+    public function testFormatShortInterim(PersonnummerData $num): void
+    {
+        $p = Personnummer::parse($num->separatedFormat, $this->options);
+        self::assertEquals($p->format(true), $num->longFormat);
+        self::assertEquals($p->format(false), $num->separatedFormat);
+    }
+
+    #[DataProvider('invalidProvider')]
+    public function testInvalidInterimThrows(PersonnummerData $num): void
+    {
+        $this->assertThrows(
+            PersonnummerException::class,
+            fn () => Personnummer::parse($num->longFormat, $this->options)
+        );
+        $this->assertThrows(
+            PersonnummerException::class,
+            fn () => Personnummer::parse($num->separatedFormat, $this->options)
+        );
+    }
+
+    #[DataProvider('validProvider')]
+    public function testInterimThrowsIfNotActive(PersonnummerData $num): void
+    {
+        $this->assertThrows(
+            PersonnummerException::class,
+            fn () => Personnummer::parse($num->longFormat, [
+                'allowInterimNumber' => false,
+            ])
+        );
+        $this->assertThrows(
+            PersonnummerException::class,
+            fn () => Personnummer::parse($num->separatedFormat, [
+                'allowInterimNumber' => false,
+            ])
+        );
+    }
+}

--- a/tests/PersonnummerData.php
+++ b/tests/PersonnummerData.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Personnummer\Tests;
 
 class PersonnummerData
@@ -14,7 +15,6 @@ class PersonnummerData
         $this->isMale = $p['isMale'];
         $this->isFemale = $p['isFemale'];
     }
-
     public string $longFormat;
     public string $shortFormat;
     public string $separatedFormat;

--- a/tests/PersonnummerData.php
+++ b/tests/PersonnummerData.php
@@ -1,0 +1,26 @@
+<?php
+namespace Personnummer\Tests;
+
+class PersonnummerData
+{
+    public function __construct(array $p)
+    {
+        $this->longFormat = $p['long_format'];
+        $this->shortFormat = $p['short_format'];
+        $this->separatedFormat = $p['separated_format'];
+        $this->separatedLong = $p['separated_long'];
+        $this->valid = $p['valid'];
+        $this->type = $p['type'];
+        $this->isMale = $p['isMale'];
+        $this->isFemale = $p['isFemale'];
+    }
+
+    public string $longFormat;
+    public string $shortFormat;
+    public string $separatedFormat;
+    public string $separatedLong;
+    public bool $valid;
+    public string $type;
+    public bool $isMale;
+    public bool $isFemale;
+}

--- a/tests/PersonnummerTest.php
+++ b/tests/PersonnummerTest.php
@@ -227,4 +227,13 @@ class PersonnummerTest extends TestCase
         }, E_USER_NOTICE);
         $this->assertFalse(isset(Personnummer::parse('121212-1212')->missingProperty));
     }
+
+    public function testIsNotInterim(): void
+    {
+        foreach (self::$testdataList as $testdata) {
+            if ($testdata['valid']) {
+                $this->assertFalse(Personnummer::parse($testdata['separated_format'])->isInterimNumber());
+            }
+        }
+    }
 }


### PR DESCRIPTION
**Type of change**

- [X] New feature

**Description**

This PR includes a few different changes to make the package adhere to the v3.1 specification (https://github.com/personnummer/meta#package-specification-v31).  

Interim numbers have been introduced to the package. Tests included.  
A strlen check have been made on the initial input (in constructor), throwing an error if the string is under 10 chars and over 13 (if it is, it's not a correctly formatted number and can be discarded directly).

The `public function getDate() : Date;` implementation have not yet been added, hence, the package will not be fully ready for a 3.1 compliant release, while, if released, it should most likely be a major or minor release (seeing this is a lot more than a patch change).

**Related issue**

https://github.com/personnummer/php/issues/60

**Motivation**

We want the packages to be using the latest spec! :)

**Checklist**

- [X] I have read the **CONTRIBUTING** document.
- [X] I have read and accepted the **Code of conduct**
- [X] Tests passes.
- [X] Style lints passes.
- [X] Documentation of new public methods exists.
- [X] New tests added which covers the added code.
- [X] Documentation is updated.